### PR TITLE
Add SimTookKitPro

### DIFF
--- a/Casks/s/simtoolkitpro.rb
+++ b/Casks/s/simtoolkitpro.rb
@@ -1,0 +1,29 @@
+cask "simtoolkitpro" do
+  version "1.2.3"
+  sha256 "88de297d96c508b0332c6adb969b88783fbac665f8527ee25cc0e3dbffa4352a"
+
+  url "https://github.com/simtoolkitpro/stkp-client-releases/releases/download/v#{version}/SimToolkitPro-#{version}-x64.Setup.dmg",
+      verified: "github.com/simtoolkitpro/stkp-client-releases/"
+  name "simtoolkitpro"
+  desc "EFB Software for your simulator"
+  homepage "https://simtoolkitpro.co.uk/"
+
+  livecheck do
+    url "https://github.com/simtoolkitpro/stkp-client-releases"
+    regex(/^v(\d+\.\d+\.\d+)$/i)
+    strategy :github_releases
+  end
+
+  auto_updates true
+
+  app "SimToolkitPro.app"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/SimToolkitPro_*.plist",
+    "~/Library/Application Support/simtoolkitpro",
+    "~/Library/Logs/SimToolkitPro",
+    "~/Library/Preferences/xyligo.stkp.plist",
+    "~/Library/Saved Application State/xyligo.stkp.savedState",
+    "~/Documents/SimToolkitPro",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Notes:

This cask does not pass `brew audit --new-cask`.

```console
audit for simtoolkitpro: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
xfoxfu/tap/simtoolkitpro
  * line 5, col 2: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

However, this software is not an open-source software on GitHub, and the authors just use GitHub releases to distribute it. I wonder if this could be an exception.